### PR TITLE
fix bugs for 1.2 release

### DIFF
--- a/get.js
+++ b/get.js
@@ -19,14 +19,16 @@ const parse_eula = x => x
     .replace(/<\/p.*?>/g, '\n')
     .replace(/<.*?>/g, '')
     .replace(/\t/g, ' ').trim();
-const p = (f, x) => {let data = '';
+const p = (f, e, x) => {let data = '';
     x.on('data', x => data += x).on('end', ()=>
-    {try{log(f(data))}catch(e){log("'version");exit(1);}});}
+    {try{log(f(data))}catch(e){bail(`'${e}`);}});}
 
 if (argv[2] == 'url') {
-    get(api, {headers}, p.bind(null, parse_url));
+    get(api, {headers}, p.bind(null, parse_url, "'version"))
+    .on('error', bail.bind(null, "'internet"));
 } else if (argv[2] == 'eula') {
-    get(license, {}, p.bind(null, parse_eula));
+    get(license, {}, p.bind(null, parse_eula, "'license"))
+    .on('error', bail.bind(null, "'internet"));
 } else {
     bail(usage);
 }

--- a/get.sh
+++ b/get.sh
@@ -1,36 +1,28 @@
 #!/bin/bash
-#===================================================================================
-#
-# FILE: get.sh
-#
+
 # USAGE: get.sh [version tag]
 #
 # DESCRIPTION: Download and unpack k binary from anaconda.org
 # Use 'main', 'dev' or the release date in 'yyyy.mm.dd' format.
 # The script downloads the latest 'dev' version by default.
-#
-# OPTIONS: see 'usage' and 'description'
-# REQUIREMENTS: ---
-# BUGS: ---
-# NOTES: ---
-# AUTHOR: regents of kparc <k@kparc.io>
-# COMPANY: kparc inc.
-# VERSION: 1.1.1
-# CREATED: 07.08.2019
-# REVISION: 23.08.2019
-#===================================================================================
 
-u=$(node get.min.js url $1)                     # download url
-test $? -ne 0 && echo "$u" && exit 1
-sp=$(test -f eula.crc && cat eula.crc)            # last accepted license checksum
-b=$(basename "$u")                              # archive file basename
-test $? -ne 0 || test -z "$b" && echo "'url" && exit 1
-set -e
-l=$(node get.min.js eula)                       # license text
-s=$(echo "$l" | cksum)                          # current license checksum
+if [ -r "get.js" ];
+then
+    gjs="get.js"
+else
+    gjs="get.min.js"
+fi
+u=$(node $gjs url $1)
+test $? -ne 0 && printf "$u\n" && exit 1
+sp=$(test -f eula.crc && cat eula.crc)
+b=$(basename "$u")
+test $? -ne 0 || test -z "$b" && printf "'url\n" && exit 1
+l=$(node $gjs eula)
+test $? -ne 0 && printf "$l\n" && exit 1
+s=$(printf "$l" | cksum)
 cd "$(dirname "$0")"
 
-download () {                                   # download and unpack
+download () {
     printf "downloading $b from anaconda.org..."
     curl -Ls $u | tar -jxf - "bin/k" && printf "done.\n\n"
 }
@@ -40,14 +32,13 @@ then
     download
 else
     cols=$(stty size | cut -d ' ' -f 2)
-    echo "$l" | fmt -w $(($cols - 4))
+    printf "$l\n" | fmt -w $(($cols - 4))
     while true
     do
-        echo
-        read -r -p "Do you agree with the terms of the Evaluation Agreement? [Y/n] " input
+        read -r -p "Do you agree with the terms of the Evaluation Agreement? [y/n] " input
         case $input in
         [yY][eE][sS]|[yY])
-            echo "$s" > eula.crc
+            printf "$s" > eula.crc
             download
             break
         ;;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "bin/k",
   "scripts": {
     "preinstall": "./get.sh",
-    "prepublishOnly": "rm -f bin/k; uglifyjs --toplevel -c -m --ecma 6 get.js > get.min.js"
+    "prepack": "rm -f bin/k",
+    "prepublishOnly": "uglifyjs --toplevel -c -m --ecma 6 get.js > get.min.js"
   },
   "bin": {
     "k": "bin/k"


### PR DESCRIPTION
changes:
* local `npm i` now uses get.js instead of get.min.js (i could not find a better solution) (#7)
* there is no `set -e` anymore, but `test $?` was added where necessary (#8)
* fixed bugs in get.js (#5)